### PR TITLE
Add terraform deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,40 @@ cython_debug/
 # vscode settings
 .vscode/
 
-# terraform providers
-.terraform/
+# Local .terraform directories
+**/.terraform/*
 
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# Ignore terraform lock files
+**/.terraform.lock.hcl

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,45 @@
+# Deployment Pipeline Guide
+
+This guide provides instructions for building and deploying the `data-catalog` frontend. The
+`data-catalog` is deployed as a GCP Cloud Run service via `terraform`. Terraform state is stored in
+a GCP Cloud bucket via terraform's `gcs` remote backend.
+
+**Requirements**
+
+- `terraform`
+- `gcloud` CLI
+
+<details>
+<summary>Installing and Configuring <code>terraform</code> and <code>gcloud</code></summary>
+
+1. Install `terraform`
+
+    Follow [this](https://learn.hashicorp.com/tutorials/terraform/install-cli) guide to install
+   `terraform`.
+
+2. Install `gcloud` CLI
+
+    Mac via homebrew: `brew install --cask google-cloud-sdk`. See
+    [homebrew](https://formulae.brew.sh/cask/google-cloud-sdk) page for more details.
+
+    Other platforms, follow [this](https://cloud.google.com/sdk/docs/install) guide.
+
+3. Configure `gcloud`
+
+    Follow [this](https://cloud.google.com/sdk/docs/authorizing) guide to configure and authenticate
+    with `gcloud`.
+
+4. Configure `terraform` with `gcloud`
+
+    For `terraform` to create, modify, and delete cloud infrastructure, it will need your `gcloud`
+    credentials. To provide `terraform` access to this information, run `gcloud auth
+    application-default login`.
+
+    For more information, see [this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#primary-authentication) resource.
+
+</details>
+
+0. The following commands should be run from the `terraform/` directory
+1. Initialize terraform: `terraform init`
+2. Adjust `TAG` version as necessary in `deploy.sh`
+3. Run `./deploy.sh`. This will build a new docker image, tag it with the version from step 2, push the image to CUAHSI's GCP docker artifact repository, and deploy the image using terraform.

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "gcs" {
+    bucket = "cuahsi-terraform-state-storage"
+    # parent "folder" of tf state file in bucket
+    prefix = "iguide-data-catalog"
+  }
+}

--- a/terraform/deploy.sh
+++ b/terraform/deploy.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+IMAGE=us-central1-docker.pkg.dev/thredds/iguide/data-catalog
+TAG=0.0.8
+
+# build
+docker build ../frontend -t ${IMAGE}:${TAG}
+
+# push
+docker push ${IMAGE}:${TAG}
+
+# deploy
+terraform apply -var="image=${IMAGE}:${TAG}" -auto-approve

--- a/terraform/frontend.tf
+++ b/terraform/frontend.tf
@@ -1,0 +1,55 @@
+provider "google" {
+  project = "thredds"
+  region  = "us-central1"
+  zone    = "us-central1-c"
+}
+
+resource "google_cloud_run_service" "default" {
+  name     = "iguide-catalog"
+  location = "us-central1"
+  provider = google
+
+  template {
+
+    metadata {
+      annotations = {
+        "autoscaling.knative.dev/maxScale" = "4"
+      }
+    }
+
+    spec {
+      # service_account_name = google_service_account.service_account.email
+      containers {
+        image = var.image
+        resources {
+          limits = {
+            cpu    = "1000m"
+            memory = "256M"
+          }
+        }
+        ports {
+          name           = "http1"
+          container_port = 8080
+          protocol       = "TCP"
+        }
+      }
+    }
+  }
+}
+
+data "google_iam_policy" "noauth" {
+  binding {
+    role = "roles/run.invoker"
+    members = [
+      "allUsers",
+    ]
+  }
+}
+
+resource "google_cloud_run_service_iam_policy" "noauth" {
+  location = google_cloud_run_service.default.location
+  project  = google_cloud_run_service.default.project
+  service  = google_cloud_run_service.default.name
+
+  policy_data = data.google_iam_policy.noauth.policy_data
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,4 @@
+variable "image" {
+  type        = string
+  description = "image and tag"
+}


### PR DESCRIPTION
Adds guide with instructions for installing and configuring `terraform`/`gcloud` and running the deployment pipeline.

Pinging @Castronova, so you are aware of this.